### PR TITLE
Fix asm_hrefk().

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ SKIPPED_LUA_TEST=
 SKIPPED_LUA_TEST_x86_64=mul div
 SKIPPED_LUA_TEST_i686=mul div
 # Below features have not been implemented on aarch64.
-SKIPPED_LUA_TEST_aarch64=div calln callxs
+SKIPPED_LUA_TEST_aarch64=div callxs
 
 # Find all tests inside the folder.
 LUA_TEST_SRC=$(wildcard *.lua)

--- a/test/calln.lua
+++ b/test/calln.lua
@@ -1,9 +1,8 @@
 x = 0
+y = math.sinh(51)
 
 for i = -50, 51 do
   x = x + math.sinh(i)
 end
-
-y = math.sinh(51)
 
 assert(x == y, "Got " .. x .. ", expect " .. y)


### PR DESCRIPTION
Primitive types has not been tested. But now it passes test_calln().

But there still seems to be bugs in runtime or transition code. Will
need to create some simple test cases to reproduce the issue.

Change-Id: I4fbb3535cb1ca0b769dd72f43ae0d82d02638556