### PR TITLE
IR_ASTORE and some related changes.

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -722,10 +722,9 @@ static void asm_ahuvload(ASMState *as, IRIns *ir)
 
 static void asm_ahustore(ASMState *as, IRIns *ir)
 {
-  lua_todo(); /* !!!TODO x86 has loads of GC64 changes here */
   if (ir->r != RID_SINK) {
     RegSet allow = RSET_GPR;
-    Reg idx, src = RID_NONE, type = RID_NONE;
+    Reg idx, src = RID_NONE, tmp = RID_NONE;
     int32_t ofs = 0;
     if (irt_isnum(ir->t)) {
       src = ra_alloc1(as, ir->op2, RSET_FPR);
@@ -736,11 +735,32 @@ static void asm_ahustore(ASMState *as, IRIns *ir)
 	src = ra_alloc1(as, ir->op2, allow);
 	rset_clear(allow, src);
       }
-      type = ra_allock(as, (int32_t)irt_toitype(ir->t)<<15, allow);
-      idx = asm_fuseahuref(as, ir->op1, &ofs, rset_exclude(allow, type), A64I_STRw);
-      if (ra_hasreg(src))
-	emit_lso(as, A64I_STRw, src, idx, ofs); /* !!!TODO STRx? */
-      emit_lso(as, A64I_STRw, type, idx, ofs+4); /* !!!TODO STRx? */
+      tmp = ra_scratch(as, allow);
+      idx = asm_fuseahuref(as, ir->op1, &ofs, rset_exclude(allow, tmp),
+			   A64I_STRx);
+      emit_lso(as, A64I_STRx, tmp, idx, ofs);
+      if (ra_hasreg(src)) {
+	if (irt_isinteger(ir->t)) {
+	  /* Merge TISNUM with zero-extended integer. */
+	  emit_dnm(as, A64I_ADDx|A64F_EX(A64EX_UXTW), tmp, tmp, src);
+	  emit_d(as, A64I_MOVZx|(((LJ_TISNUM>>1)&0xffff)<<5)|
+	         A64F_LSL16(48), tmp);
+	} else {
+	  emit_dnm(as, A64I_ADDx|A64F_SH(A64SH_LSL, 47), tmp, src, tmp);
+	  emit_d(as, A64I_MOVNx|(((~irt_toitype(ir->t))&0xffff)<<5), tmp);
+	}
+      } else {
+	/* TODO: We should probably allocate a register for these.
+	 * But how should we allocate a register for a 64-bit constant? */
+	IRType t = irt_type(ir->t);
+	if (t == IRT_TRUE) {
+	  emit_d(as, A64I_MOVNx|(0x0001<<5)|A64F_LSL16(48), tmp);
+	} else if (t == IRT_FALSE) {
+	  emit_d(as, A64I_MOVNx|(0x8000<<5)|A64F_LSL16(32), tmp);
+	} else {
+	  emit_d(as, A64I_MOVNx, tmp);
+	}
+      }
     }
   }
 }

--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -787,7 +787,7 @@ static void asm_sload(ASMState *as, IRIns *ir)
 	dest = tmp;
 	t.irt = IRT_INT;  /* Check for original type. */
       }
-    } else if (irt_isint(t)) {
+    } else if (irt_isint(t) && (ir->op2 & IRSLOAD_TYPECHECK)) {
       emit_dn(as, A64I_SXTW, dest, dest);
     }
     goto dotypecheck;
@@ -828,7 +828,8 @@ dotypecheck:
   }
   if (ra_hasreg(dest)) {
     /* TODO: Do we need to check if offset is out-of-range? */
-    emit_lso(as, irt_isnum(t) ? A64I_LDRd : A64I_LDRx, (dest & 31), base, ofs);
+    emit_lso(as, irt_isnum(t) ? A64I_LDRd :
+	     (irt_isint(t) ? A64I_LDRw : A64I_LDRx), (dest & 31), base, ofs);
   }
 }
 

--- a/src/lj_target_arm64.h
+++ b/src/lj_target_arm64.h
@@ -142,17 +142,22 @@ typedef enum A64CC {
 #define A64F_S19(x)	((x) << 5)
 #define A64F_COND(cc)   ((cc) << 12)  /* for CCMP */
 #define A64F_NZCV(nzcv) ((nzcv) << 0) /* for CCMP */
+#define A64F_EX(ex)	(A64I_EX | ((ex) << 13))
 #define A64F_SH(sh, n)	(((sh) << 22) | ((n) << 10))
+#define A64F_LSL16(n)	(((n) / 16) << 21)
 #define A64F_BSH(sh)    ((sh) << 10)
 
 typedef enum A64Ins {
   A64I_S = 0x20000000,
+  A64I_EX = 0x00200000,
   A64I_MOVK_16w = 0x72a00000,
   A64I_MOVK_16x = 0xf2a00000,
   A64I_MOVK_32x = 0xf2c00000,
   A64I_MOVK_48x = 0xf2e00000,
   A64I_MOVZw = 0x52800000,
   A64I_MOVZx = 0xd2800000,
+  A64I_MOVNw = 0x12800000,
+  A64I_MOVNx = 0x92800000,
   A64I_MOVw = 0x2a0003e0,
   A64I_MOVx = 0xaa0003e0,
   A64I_LDRBw = 0x39400000,
@@ -274,5 +279,10 @@ typedef enum A64Ins {
 typedef enum A64Shift {
   A64SH_LSL, A64SH_LSR, A64SH_ASR, A64SH_ROR
 } A64Shift;
+
+typedef enum A64Extend {
+  A64EX_UXTB, A64EX_UXTH, A64EX_UXTW, A64EX_UXTX,
+  A64EX_SXTB, A64EX_SXTH, A64EX_SXTW, A64EX_SXTX,
+} A64Extend;
 
 #endif

--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1799,6 +1799,7 @@ static void build_subroutines(BuildCtx *ctx)
   |.if JIT
   |  ldr LFUNC:CARG3, [BASE, FRAME_FUNC]  // Same as curr_topL(L).
   |   add CARG1, GL, #GG_G2DISP+GG_DISP2J
+  |  and LFUNC:CARG3, CARG3, #LJ_GCVMASK
   |   str PC, SAVE_PC
   |  ldr CARG3, LFUNC:CARG3->field_pc
   |   mov CARG2, PC
@@ -1924,7 +1925,6 @@ static void build_subroutines(BuildCtx *ctx)
   |   str CARG4, [TMP0, TMP1]
   |  sub CARG1, TMP0, #-GG_DISP2J
   |  mov CARG2, sp
-  |  ldr GL, L->glref
   |  bl extern lj_trace_exit            // (jit_State *J, ExitState *ex)
   |  // Returns MULTRES (unscaled) or negated error code.
   |  ldr CARG2, L->cframe
@@ -1948,6 +1948,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  blt >9				// Check for error from exit.
   |   lsl RC, CARG1, #3
   |  ldr LFUNC:CARG2, [BASE, FRAME_FUNC]
+  |    movz TISNUM, #(LJ_TISNUM>>1)&0xffff, lsl #48
+  |    movz TISNUMhi, #(LJ_TISNUM>>1)&0xffff, lsl #16
+  |    movn TISNIL, #0
   |   str RC, SAVE_MULTRES
   |   mov CARG3, #0
   |   str BASE, L->base

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,9 +8,7 @@ SKIPPED_LUA_TEST_x86_64=mul div
 SKIPPED_LUA_TEST_i686=mul div
 # Below features have not been implemented on aarch64.
 SKIPPED_LUA_TEST_aarch64=div callxs \
-  hstore_pri hstore_str astore_pri astore_num astore_str ustore \
-  aload_bool aload_num aload_str uload \
-  snew xsnew tnew cnew cnewi tdup
+  ustore uload snew cnew cnewi
 
 # Find all tests inside the folder.
 LUA_TEST_SRC=$(wildcard *.lua)

--- a/test/astore_other.lua
+++ b/test/astore_other.lua
@@ -1,0 +1,44 @@
+do
+  -- IR_ASTORE: int
+  local a = {}
+  for i=1,100 do
+    a[i] = i
+  end
+  assert(a[100]==100)
+end
+
+do
+  -- IR_ASTORE: num
+  local a = {}
+  for i=1,100 do
+    a[i] = 5.5
+  end
+  assert(a[100]==5.5)
+end
+
+do
+  -- IR_ASTORE: false
+  local a = {}
+  for i=1,100 do
+    a[i] = false
+  end
+  assert(not a[100])
+end
+
+do
+  -- IR_ASTORE: true
+  local a = {}
+  for i=1,100 do
+    a[i] = true
+  end
+  assert(a[100])
+end
+
+do
+  -- IR_ASTORE: addr
+  local a = {}
+  for i=1,100 do
+    a[i] = ""
+  end
+  assert(a[100] == "")
+end


### PR DESCRIPTION
Most of this patch are modifications to asm_ahustore, which seems to work well, but x86 has some changes that handle constant operands in a special way, which I haven't implemented, since I don't fully understand it. Anyway, I don't have any examples that fail.
You can also see some changes in interpreter code. The change in lj_vm_hotcall fixed a problem in ustore.lua test (which still fails, but for a different reason), because it loaded a tagged LFUNC and yielded segfault. I just added instruction for untagging.
The other change loads TISNUM and TISNIL constants to the registers that are supposed to hold them in interpreter. I had issue with this in one of the ASTORE examples. Interpreter was using TISNUM register to tag array size, while TISNUM was holding some trash value and that later caused segfault.
I also added some of my own tests, just to avoid regressions. They are not in the same style (sorry about that) as current tests, but I wanted to keep them the same as I used for debugging.
I also removed some tests from the skip-list, beucase they are passing now.