### PR TITLE
Fixed IR_ULOAD and IR_USTORE.

### DIFF
--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1950,6 +1950,7 @@ static void build_subroutines(BuildCtx *ctx)
   |    movz TISNUM, #(LJ_TISNUM>>1)&0xffff, lsl #48
   |    movz TISNUMhi, #(LJ_TISNUM>>1)&0xffff, lsl #16
   |    movn TISNIL, #0
+  |  and LFUNC:CARG2, CARG2, #LJ_GCVMASK
   |   str RC, SAVE_MULTRES
   |   mov CARG3, #0
   |   str BASE, L->base
@@ -1986,6 +1987,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  decode_RA CARG1, CARG3
   |  sub CARG2, BASE, CARG1
   |  ldr LFUNC:CARG3, [CARG2, #-16]
+  |  and LFUNC:CARG3, CARG3, #LJ_GCVMASK
   |  ldr CARG3, LFUNC:CARG3->field_pc
   |  ldr KBASE, [CARG3, #PC2PROTO(k)]
   |  b <2

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ SKIPPED_LUA_TEST_x86_64=mul div
 SKIPPED_LUA_TEST_i686=mul div
 # Below features have not been implemented on aarch64.
 SKIPPED_LUA_TEST_aarch64=div callxs \
-  ustore uload snew cnew cnewi \
+  snew cnew cnewi \
   vload xstore_addvalue fstore xload \
   abs atan2 ldexp max min mod pow \
   eq_other ge_none_num gt_none_num \


### PR DESCRIPTION
This patch fixes upvalue load/store. These are some of the things that I feel need explaining:
 - Interpreter: Trying to access untagged LFUNC caused segfault. Added instruction to remove tag.
 - emit_lsptr: Since we now have GL register that holds a pointer to global_State, we can try to load things relative to it, if the offset is close enough.