### PR TITLE
Allow IR_ADD and IR_SUB to work with 64-bit values

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -990,7 +990,7 @@ static void asm_add(ASMState *as, IRIns *ir)
       asm_fparith(as, ir, A64I_FADDd);
     return;
   }
-  asm_intop_s(as, ir, A64I_ADDw); /* !!!TODO this drops the tag, is it wrong? */
+  asm_intop_s(as, ir, irt_is64(ir->t) ? A64I_ADDx : A64I_ADDw);
 }
 
 static void asm_sub(ASMState *as, IRIns *ir)
@@ -999,7 +999,7 @@ static void asm_sub(ASMState *as, IRIns *ir)
     asm_fparith(as, ir, A64I_FSUBd);
     return;
   }
-  asm_intop_s(as, ir, A64I_SUBw); /* !!!TODO this drops the tag, is it wrong? */
+  asm_intop_s(as, ir, irt_is64(ir->t) ? A64I_SUBx : A64I_SUBw);
 }
 
 static void asm_mul(ASMState *as, IRIns *ir)


### PR DESCRIPTION
IR_ADD/SUB should be able to work with pointers and other 64-bit values. This patch allows them to do so. `vload.lua` test reproduces the incorrect behavior.