### PR TITLE
Stack check/restore

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -1464,7 +1464,7 @@ static void asm_stack_restore(ASMState *as, SnapShot *snap)
   for (n = 0; n < nent; n++) {
     SnapEntry sn = map[n];
     BCReg s = snap_slot(sn);
-    int32_t ofs = 8*((int32_t)s-1);
+    int32_t ofs = 8*((int32_t)s-1-LJ_FR2);
     IRRef ref = snap_ref(sn);
     IRIns *ir = IR(ref);
     if ((sn & SNAP_NORESTORE))


### PR DESCRIPTION
Implemented `asm_stack_check` and fixed a minor issue in `asm_stack_restore` (it was causing a branch target to be to the branch itself).