### PR TITLE
Minor fixes in exit_interp

### DIFF
--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1940,7 +1940,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  // arm64: BASE, PC, L, GL need to be set. They are when coming from
   |  //        vm_exit_handler, but what about when entering here?
   |.if JIT
-  |  NYI
   |  ldr L, SAVE_L
   |1:
   |  cmp CARG1, #0

--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1971,9 +1971,10 @@ static void build_subroutines(BuildCtx *ctx)
   |   lsr TMP0, INS, #16
   |   csel RC, TMP0, RC, lo
   |   blo >5
+  |   ldr CARG3, [BASE, FRAME_FUNC]
   |   sub RC, RC, #8
   |   add RA, RA, BASE	// Yes: RA = BASE+framesize*8, RC = nargs*8
-  |   ldr CARG3, [BASE, FRAME_FUNC]
+  |   and LFUNC:CARG3, CARG3, #LJ_GCVMASK
   |5:
   |  br RB
   |

--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1962,6 +1962,7 @@ static void build_subroutines(BuildCtx *ctx)
   |   ldr INSw, [PC], #4
   |    st_vmstate CARG4
   |  cmp RBw, #BC_FUNCC+2		// Fast function?
+  |   add TMP1, GL, INS, uxtb #3
   |  bhs >4
   |2:
   |  cmp RBw, #BC_FUNCF			// Function header?


### PR DESCRIPTION
There are a few changes here. I ran into NYI in exit_interp in a few tests, so I removed it and some of the tests passed and it didn't seem to break anything else.
Ran into segmentation fault due to CARG3 being tagged, so I decided to clear the tag here. And that seems to be common thing in the rest of the code (clearing tag from loaded FRAME_FUNC).
I also ran into an issue with TMP1. It needs to be loaded with the proper address. I didn't know exactly where to put the instruction, but it seemed to work where I put it and didn't break anything.