### PR TITLE
Add and change IR_TOSTR test cases.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@ SKIPPED_LUA_TEST_aarch64=div call_vararg \
   fpm_ceil fpm_exp fpm_floor fpm_log fpm_log10 fpm_sin fpm_sqrt fpm_tan fpm_trunc \
   fpm_exp2 fpm_log2 fref href newref urefc urefo \
   bnot bsar bshl bshr bswap \
-  tostr_char conv_flt2num conv_num2flt
+  conv_flt2num conv_num2flt
 
 # Find all tests inside the folder.
 LUA_TEST_SRC=$(wildcard *.lua)

--- a/test/tostr_int.lua
+++ b/test/tostr_int.lua
@@ -1,8 +1,10 @@
--- test IR_TOSTR for char type.
+-- test IR_TOSTR for int type.
+x = 0
 
 for i = 1, 100 do
-   x = tostring(string.char(i))
+  x = tostring(i)
 end
 
-y = "d"
+y = "100"
+
 assert(x == y, "Got " .. x .. ", expect " .. y)


### PR DESCRIPTION
Reduce scope of tostr_char.lua to make it not generate IR_STRREF.

Add tostr_int.lua.

Change-Id: Icede2f76bfa4e9d1323653d14962ae556ffc068a