### PR TITLE
Fix register numbers for FP loads/stores.

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -782,7 +782,7 @@ static void asm_fload(ASMState *as, IRIns *ir)
     }
     ofs = field_ofs[ir->op2];
   }
-  emit_lso(as, ai, dest, idx, ofs);
+  emit_lso(as, ai, dest & 31, idx, ofs);
 }
 
 static void asm_fstore(ASMState *as, IRIns *ir)
@@ -799,7 +799,7 @@ static void asm_fstore(ASMState *as, IRIns *ir)
       idx = ra_alloc1(as, irf->op1, rset_exclude(RSET_GPR, src));
       ofs = field_ofs[irf->op2];
     }
-    emit_lso(as, ai, src, idx, ofs);
+    emit_lso(as, ai, src & 31, idx, ofs);
   }
 }
 
@@ -1556,7 +1556,7 @@ static void asm_stack_restore(ASMState *as, SnapShot *snap)
       continue;
     if (irt_isnum(ir->t)) {
       Reg src = ra_alloc1(as, ref, RSET_FPR);
-      emit_lso(as, A64I_STRd, src, RID_BASE, ofs);
+      emit_lso(as, A64I_STRd, src & 31, RID_BASE, ofs);
     } else {
       lua_assert(irt_ispri(ir->t) || irt_isaddr(ir->t) ||
                  (LJ_DUALNUM && irt_isinteger(ir->t)));

--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -227,6 +227,9 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int32_t ofs)
 {
   /* !!!TODO ARM emit_lso combines LDR/STR pairs into LDRD/STRD, something
      similar possible here? */
+
+  lua_assert(rd <= 31);
+
   ofs_type ot = check_offset(ai, ofs);
   lua_assert(ot != OFS_INVALID);
   if (ot == OFS_UNSCALED) {
@@ -300,7 +303,7 @@ static void emit_loadofs(ASMState *as, IRIns *ir, Reg r, Reg base, int32_t ofs)
 static void emit_storeofs(ASMState *as, IRIns *ir, Reg r, Reg base, int32_t ofs)
 {
   if (r >= RID_MAX_GPR) {
-    emit_lso(as, irt_isnum(ir->t) ? A64I_STRd : A64I_STRs, r, base, ofs);
+    emit_lso(as, irt_isnum(ir->t) ? A64I_STRd : A64I_STRs, r & 31, base, ofs);
   } else {
     emit_lso(as, irt_is64(ir->t) ? A64I_STRx : A64I_STRw, r, base, ofs);
   }


### PR DESCRIPTION
The register numbers used in IR for FP registers range 32-63 for d0-d31. The
encoding requires the register numbers 0-31, so the register number
must be masked before passing to emit_lso.