### PR TITLE
Fix divide by -1.

### DIFF
--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -999,7 +999,7 @@ LJFOLDF(simplify_nummuldiv_k)
     return LEFTFOLD;
   } else if (n == -1.0) {  /* x o -1 ==> -x */
     fins->o = IR_NEG;
-    fins->op2 = (IRRef1)lj_ir_ksimd(J, LJ_KSIMD_NEG);
+    fins->op2 = lj_ir_k64(J, IR_KNUM, LJ_KSIMD(J, LJ_KSIMD_NEG)->u64);
     return RETRYFOLD;
   } else if (fins->o == IR_MUL && n == 2.0) {  /* x * 2 ==> x + x */
     fins->o = IR_ADD;

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,11 +3,11 @@ LUAJIT?=luajit
 LUA_FLAGS?=-jdump=+rsXa
 # Define tests which should be skipped for some reasons.
 SKIPPED_LUA_TEST=fpm_cos addov
-# mul and div on x86 fail due to issue with XCFLAGS="-DLUAJIT_ENABLE_GC64"
-SKIPPED_LUA_TEST_x86_64=mul div
-SKIPPED_LUA_TEST_i686=mul div
+# mul on x86 fail due to issue with XCFLAGS="-DLUAJIT_ENABLE_GC64"
+SKIPPED_LUA_TEST_x86_64=mul
+SKIPPED_LUA_TEST_i686=mul
 # Below features have not been implemented on aarch64.
-SKIPPED_LUA_TEST_aarch64=div call_vararg \
+SKIPPED_LUA_TEST_aarch64=call_vararg \
   snew \
   vload xstore_addvalue fstore xload_int \
   abs atan2 ldexp max min pow \


### PR DESCRIPTION
This problem affects all platforms. It was introduced by commit
ccae333844c7aad0934f13f7698894c883a6b561 (Load SIMD constants with IR_FLOAD
from GG_State)

The error is that lj_ir_ksimd is used to construct the constant in op2 of
IR_NEG, but this function actually generates an IR_FLOAD of the constant
instead. In doing so, it overwrites fins (ie J->fold.ins). The fix is to
directly reference the required constant in simplify_nummuldiv_k.