### PR TITLE
Fix asm_hrefk and add more tests

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -646,11 +646,10 @@ static void asm_hrefk(ASMState *as, IRIns *ir)
 
   uint64_t key_val = 0;
   if (irt_ispri(irkey->t)) {
-    lua_unimpl();
     lua_assert(!irt_isnil(irkey->t));
-    key_val = (uint64_t)irt_toitype(irkey->t) << 47;
+    /* primitive type's lowest 47 bits are all 1. */
+    key_val = (uint64_t)irt_toitype(irkey->t) << 47 | ((1ULL << 47) - 1);
   } else if (irt_isnum(irkey->t))  {
-    /* !!!TODO is this valid on ARM64? */
     /* Assumes -0.0 is already canonicalized to +0.0. */
     key_val = ir_knum(irkey)->u64;
   } else {

--- a/test/hrefk_num.lua
+++ b/test/hrefk_num.lua
@@ -1,0 +1,10 @@
+-- test IR_HREFK when key type is number.
+local mytable = {[1.3] = 5, [0.0] = 10000}
+
+for i = 1, 100 do
+    res = mytable[0.0] + mytable[1.3]
+end
+
+expect = 10005
+
+assert(res == expect, "Expect "..expect..", get "..res)

--- a/test/hrefk_pri.lua
+++ b/test/hrefk_pri.lua
@@ -1,0 +1,12 @@
+-- test IR_HREFK when key is primitive type.
+local a = true
+local b = false
+local mytable = {[true] = 5, [false] = 4}
+
+for i = 1, 100 do
+    res = mytable[true] + mytable[false]
+end
+
+expect = 9
+
+assert(res == expect, "Expect "..expect..", get "..res)

--- a/test/hrefk_str.lua
+++ b/test/hrefk_str.lua
@@ -1,3 +1,4 @@
+-- test IR_HREFK when key type is string.
 local mytable = {["data1"] = 5, ["data2"] = 10000, ["data3"] = -20}
 
 for i = 1, 100 do


### PR DESCRIPTION
Implement asm_hrefk() for primitive type.

Add primitive and number type test cases for asm_hrefk.

Change-Id: Ibb37c54cf8df7096898f0edd61cf5afd39f7fa79