### PR TITLE
Fix BC_UNM when input is zero.

### DIFF
--- a/src/vm_arm.dasc
+++ b/src/vm_arm.dasc
@@ -2927,6 +2927,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |   ins_next2
     |  checktp CARG2, LJ_TISNUM
     |  bhi ->vmeta_unm
+    |  // handle negative zero in vmeta_unm
+    |  cmp CARG1, #0
+    |  beq ->vmeta_unm
+    |  checktp CARG2, LJ_TISNUM
     |  eorne CARG2, CARG2, #0x80000000
     |  bne >5
     |  rsbseq CARG1, CARG1, #0

--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -2476,7 +2476,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  asr ITYPE, TMP0, #47
     |  cmn ITYPE, #-LJ_TISNUM
     |  bhi ->vmeta_unm
+    |  // handle negative zero in vmeta_unm
+    |  cmp TMP0, TISNUM
+    |  beq ->vmeta_unm
     |  eor TMP0, TMP0, #U64x(80000000,00000000)
+    |  cmn ITYPE, #-LJ_TISNUM
     |  bne >5
     |  negs TMP0w, TMP0w
     |   movz CARG3, #0x41e0, lsl #48	// 2^31.

--- a/test/unm_zero.lua
+++ b/test/unm_zero.lua
@@ -1,0 +1,7 @@
+-- test BC_UNM bytecode when input is zero
+x = 0
+neg_x_str = string.format("%+1.5g", -x)
+c = string.byte(neg_x_str, 1)
+-- '-' ascii value is 45.
+minus = 45
+assert(c==minus, "Got x = "..c.." expect "..minus)


### PR DESCRIPTION
unm_zero.lua is added to test such case.

Change-Id: I23887d239ecf8c446d9a28ec6ae5baa9bc0775f5