### PR TITLE
Fixed asm_tbar.

### DIFF
--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -175,7 +175,7 @@ static uint32_t emit_isk13(A64Ins ai, int64_t n)
     r = (clz_a + 1) & (d - 1);
   s = ((-d << 1) | (s - 1)) & 0x3f;
   res = (out_n<<12) | (r << 6) | s;
-  return res;
+  return (res<<10);
 }
 
 /* -- Emit loads/stores --------------------------------------------------- */


### PR DESCRIPTION
There was a bug in `asm_tbar`. Field `grayagain` was loaded with a wrong instruction. So I fixed that, and I felt free to clean this function up a little bit, to make it look more like ARM32 version.

You might wonder why am I not checking return value of `emit_isk13`. Well I feel that it is not necessary, because we know for fact that `LJ_GC_BLACK` fits the format, since it's a known constant.

I also changed `emit_isk13` to return a constant in the appropriate field. It made sense to me, since `emit_isk12` returns it that way as well.

Comments are welcome.