### PR TITLE
emit_isk13 needs to work with unsigned numbers.

### DIFF
--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -107,7 +107,7 @@ int count_leading_zeroes(uint64_t value)
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /******************************************************************************/
-static uint32_t emit_isk13(A64Ins ai, int64_t n)
+static uint32_t emit_isk13(A64Ins ai, uint64_t n)
 {
   int is64 = ((ai & A64I_X) != 0x0);
   uint32_t res;


### PR DESCRIPTION
One partical issue is observed on line 133. When a negative signed number is shifted right, it's signed extended, which is not the intended behaviour on this particular line.