### PR TITLE
Implement emit_jmp() #define.

### DIFF
--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -407,7 +407,7 @@ static void emit_addptr(ASMState *as, Reg r, int32_t ofs)
   }
 }
 
-#define emit_jmp(as, target) lua_unimpl()
+#define emit_jmp(as, target) emit_branch(as, A64I_B, (target))
 
 #define emit_setvmstate(as, i)                UNUSED(i)
 #define emit_spsub(as, ofs)                   emit_addptr(as, RID_SP, -(ofs))


### PR DESCRIPTION
We don't have a test case which requires this yet, but implementation is
trivial.