### PR TITLE
Disabled fusion of multiply and sub instructions.

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -1373,8 +1373,7 @@ static void asm_add(ASMState *as, IRIns *ir)
 static void asm_sub(ASMState *as, IRIns *ir)
 {
   if (irt_isnum(ir->t)) {
-    if (!asm_fusemadd(as, ir, A64I_FNMSUBd, A64I_FMSUBd))
-      asm_fparith(as, ir, A64I_FSUBd);
+    asm_fparith(as, ir, A64I_FSUBd);
     return;
   }
   asm_intop_s(as, ir, irt_is64(ir->t) ? A64I_SUBx : A64I_SUBw);


### PR DESCRIPTION
It fixes mandelbrot.lua and mandelbrot-bit.lua from https://github.com/LuaJIT/LuaJIT-test-cleanup.
Apparently, fnmsub instruction, which combines multiplication and subtraction. doesn't give as precise result as result of combined fmul and fsub instructions.