### PR TITLE
Modify ra_allock API to accept 64-bit integers.

### DIFF
--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -325,9 +325,9 @@ static Reg ra_rematk(ASMState *as, IRRef ref)
     ra_free(as, r);
     ra_modified(as, r);
 #if LJ_64
-    emit_loadi(as, r, ra_krefk(as, ref));
-#else
     emit_loadu64(as, r, ra_krefk(as, ref));
+#else
+    emit_loadi(as, r, ra_krefk(as, ref));
 #endif
     return r;
   }

--- a/src/lj_emit_arm.h
+++ b/src/lj_emit_arm.h
@@ -207,7 +207,7 @@ static void emit_loadi(ASMState *as, Reg r, int32_t i)
 
 #define emit_loada(as, r, addr)		emit_loadi(as, (r), i32ptr((addr)))
 
-static Reg ra_allock(ASMState *as, int32_t k, RegSet allow);
+static Reg ra_allock(ASMState *as, intptr_t k, RegSet allow);
 
 /* Get/set from constant pointer. */
 static void emit_lsptr(ASMState *as, ARMIns ai, Reg r, void *p)

--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -3,7 +3,7 @@
 ** Copyright !!!TODO
 */
 
-static Reg ra_allock(ASMState *as, int32_t k, RegSet allow);
+static Reg ra_allock(ASMState *as, intptr_t k, RegSet allow);
 
 #define emit_canremat(ref)      ((ref) <= ASMREF_L)
 

--- a/src/lj_emit_mips.h
+++ b/src/lj_emit_mips.h
@@ -94,8 +94,8 @@ static void emit_loadi(ASMState *as, Reg r, int32_t i)
 
 #define emit_loada(as, r, addr)		emit_loadi(as, (r), i32ptr((addr)))
 
-static Reg ra_allock(ASMState *as, int32_t k, RegSet allow);
-static void ra_allockreg(ASMState *as, int32_t k, Reg r);
+static Reg ra_allock(ASMState *as, intptr_t k, RegSet allow);
+static void ra_allockreg(ASMState *as, intptr_t k, Reg r);
 
 /* Get/set from constant pointer. */
 static void emit_lsptr(ASMState *as, MIPSIns mi, Reg r, void *p, RegSet allow)

--- a/src/lj_emit_ppc.h
+++ b/src/lj_emit_ppc.h
@@ -98,7 +98,7 @@ static void emit_loadi(ASMState *as, Reg r, int32_t i)
 
 #define emit_loada(as, r, addr)		emit_loadi(as, (r), i32ptr((addr)))
 
-static Reg ra_allock(ASMState *as, int32_t k, RegSet allow);
+static Reg ra_allock(ASMState *as, intptr_t k, RegSet allow);
 
 /* Get/set from constant pointer. */
 static void emit_lsptr(ASMState *as, PPCIns pi, Reg r, void *p, RegSet allow)


### PR DESCRIPTION
I've only changed API in this commit to allow `ra_allock` to allocate 64-bit constants. I will go on and try to use `ra_allock` where possible, but I will create a separate pull request for that.

Some comments on the implementation:

As you can see, I've changed `int32_t` to `intptr_t`, where it was necessary. I'm not sure If this is the right way to go, but (to me) it seems reasonable. There are currently no 64-bit architectures that use `ra_allock`, so it should only affect ARM64. 32-bit architectures shouldn't suffer either since their `intptr_t` and `int32_t` should be the same (or should they? :)).

There are also some awkward parts like `ra_rematk`, where `intptr_t` is passed to `emit_loadu64`, which accepts `uint64_t`. That shouldn't cause any issues (as far as I know), but feels awkward to me.

The other part that is somewhat weird is `ra_allockreg` definition. For architectures that use this kind of constant allocation, this function accepts `intptr_t`, but for architectures that don't, `ra_allockreg` is replaced with `emit_loadi` which accepts `int32_t`, which feels inconsistent.

I'm open to suggestions.